### PR TITLE
Switch to denormal/go-gitignore

### DIFF
--- a/archive_filter.go
+++ b/archive_filter.go
@@ -46,9 +46,8 @@ func FilterPatterns(r io.Reader) (Filter, error) {
 	return FilterFunc(func(info os.FileInfo) bool {
 		if match := filter.Relative(info.Name(), info.IsDir()); match != nil {
 			return match.Ignore()
-		} else {
-			return false
 		}
+		return false
 	}), nil
 }
 

--- a/archive_filter.go
+++ b/archive_filter.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/monochromegane/go-gitignore"
+	"github.com/denormal/go-gitignore"
 )
 
 // Filter is the interface used to filter on files.
@@ -40,10 +40,15 @@ func isDot(s string) bool {
 
 // FilterPatterns filters on the given reader.
 func FilterPatterns(r io.Reader) (Filter, error) {
-	filter := gitignore.NewGitIgnoreFromReader(".", r)
+	// Ignore errors by default
+	filter := gitignore.New(r, ".", func(e gitignore.Error) bool { return true })
 
 	return FilterFunc(func(info os.FileInfo) bool {
-		return filter.Match(info.Name(), info.IsDir())
+		if match := filter.Relative(info.Name(), info.IsDir()); match != nil {
+			return match.Ignore()
+		} else {
+			return false
+		}
 	}), nil
 }
 

--- a/archive_filter_test.go
+++ b/archive_filter_test.go
@@ -98,6 +98,37 @@ func TestFilterPatterns_negate(t *testing.T) {
 	cases.Test(t, f)
 }
 
+func TestFilterPattern_deeply_nested(t *testing.T) {
+	cases := filterCases{
+		file(".git", false),
+		file("readme.md", false),
+		file("server", true),
+
+		file("node_modules", true),
+
+		file("package.json", false),
+		file("node_modules/foo/package.json", true),
+
+		file("src/main.go", false),
+		file("node_modules/bar/src", true),
+		file("node_modules/bar/src/index.js", true),
+	}
+
+	patterns := strings.NewReader(`
+.git
+readme.md
+src/**
+package.json
+!node_modules/**
+!server
+`)
+
+	f, err := FilterPatterns(patterns)
+	assert.NoError(t, err, "filter")
+
+	cases.Test(t, f)
+}
+
 func TestFilterPatternFiles(t *testing.T) {
 	cases := filterCases{
 		file("server", true),


### PR DESCRIPTION
> If errors is given, it will be invoked for every error encountered when parsing the .gitignore patterns. Parsing will terminate if errors is called and returns false, otherwise, parsing will continue until end of file has been reached.

Currently we're just ignoring parsing errors, if we're okay with this we can leave it as is. Otherwise we can return false, terminate and give the user the reasons behind the failure . [L44](https://github.com/tj/go-archive/compare/master...hhsnopek:master#diff-3c716f51359db48b5e3b684f0600f58dR44)