### PR TITLE
feat: relative paths from dir

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -95,10 +95,16 @@ func (a *Archive) Open() error {
 
 // AddDir directory recursively.
 func (a *Archive) AddDir(root string) error {
-	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(root, func(abspath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
+
+		path, err := filepath.Rel(root, abspath)
+		if err != nil {
+			return err
+		}
+		path = filepath.Clean(path)
 
 		if path == "." {
 			return nil
@@ -142,7 +148,7 @@ func (a *Archive) AddDir(root string) error {
 			return nil
 		}
 
-		f, err := os.Open(path)
+		f, err := os.Open(abspath)
 		if err != nil {
 			return errors.Wrap(err, "opening file")
 		}

--- a/archive_filter_test.go
+++ b/archive_filter_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/apex/log"
-	"github.com/tj/assert"
-	"github.com/tj/go-archive"
+	"github.com/matthewmueller/go-archive"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {

--- a/archive_zip_test.go
+++ b/archive_zip_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/tj/assert"
-	"github.com/tj/go-archive"
+	"github.com/matthewmueller/go-archive"
+	"github.com/stretchr/testify/assert"
 )
 
 func init() {
@@ -189,10 +189,8 @@ func TestZipWriter_transform(t *testing.T) {
 	s, err := tree(dir)
 	assert.NoError(t, err, "tree")
 
-	expected := `testdata mode=drwxr-xr-x
-testdata/static mode=drwxr-xr-x
-testdata/static/index.html mode=-rwxrwxrwx size=117
-testdata/static/style.css mode=-rwxrwxrwx size=44
+	expected := `index.html mode=-rwxrwxrwx size=117
+style.css mode=-rwxrwxrwx size=44
 `
 
 	assert.Equal(t, expected, s)


### PR DESCRIPTION
Right now if you do something like this:

```go
buf := new(bytes.Buffer)
zip := archive.NewZip(buf).
	WithFilter(filter).
	WithTransform(transform)

if err := zip.Open(); err != nil {
	return nil, nil, errors.Wrap(err, "opening")
}

if err := zip.AddDir(dir); err != nil {
	return nil, nil, errors.Wrap(err, "adding dir")
}

if err := zip.Close(); err != nil {
	return nil, nil, errors.Wrap(err, "closing")
}
```

And `dir` is an absolute path, you'll end up with a zip file that has a ton of folders inside it, starting from the zipper's / (haha). This PR changes that behavior to have `dir` be the root of the zip.